### PR TITLE
[fix] super()__init__ of BitLlamaAttention must be passed layer_idx

### DIFF
--- a/mybitnet/bitnet/models/bit_llama/modeling_bit_llama.py
+++ b/mybitnet/bitnet/models/bit_llama/modeling_bit_llama.py
@@ -41,7 +41,7 @@ class BitLlamaMLP(LlamaMLP):
         
 class BitLlamaAttention(LlamaAttention):
     def __init__(self, config: BitLlamaConfig, layer_idx: Optional[int] = None):
-        super().__init__(config)
+        super().__init__(config, layer_idx)  # Set `layer_idx` to avoid `self.layer_idx` to be `None`
         if config.bitnet_type=="1b":
             self.q_proj = BitLinear(self.hidden_size, self.num_heads * self.head_dim, bias=False, rms_norm_eps=config.rms_norm_eps, bits=config.bits, flg_before_linear=True)
             self.k_proj = BitLinear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=False, rms_norm_eps=config.rms_norm_eps, bits=config.bits, flg_before_linear=True)


### PR DESCRIPTION
# TL;DR

- `BitLlamaAttention`内の`super().__init__`におけるバグを修正するため、引数に`layer_idx`を追加する軽微な修正を行いました。

## 背景
Hajime-Yさんの解説記事および本レポジトリを見ながらBitNet-b158の再現実装を行っています。
その際に`BitLlamaAttention`内の`super().__init__`に引数`layer_idx`が渡されていないため、`layer_idx`が`None`の状態となっており、以下の警告表示およびエラーが発生しました。

```code: shell
Instantiating BitLlamaAttention without passing a `layer_idx` is not recommended and will lead to errors during the forward call if caching is used. Please make sure to provide a `layer_idx` when creating this class.
```

```code: shell
  ...
  File ".../lib/python3.10/site-packages/transformers/models/llama/modeling_llama.py", line 1018, in forward
    layer_outputs = decoder_layer(
  File ".../lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File ".../mybitnet/bitnet/models/bit_llama/modeling_bit_llama.py", line 128, in forward
    hidden_states, self_attn_weights, present_key_value = self.self_attn(
  File ".../lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File ".../lib/python3.10/site-packages/transformers/models/llama/modeling_llama.py", line 366, in forward
    key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
  File ".../lib/python3.10/site-packages/transformers/cache_utils.py", line 142, in update
    if len(self.key_cache) <= layer_idx:
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```

## 変更点
`BitLlamaAttention`の`super().__init__`の引数に`layer_idx`を追加しました。

```code: python
+ super().__init__(config, layer_idx)  # Set `layer_idx` to avoid `self.layer_idx` to be `None`
- super().__init__(config)
```

## 参考文献
[transformers/models/llama/modeling_llama.py](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py)

